### PR TITLE
dlpack 1.1

### DIFF
--- a/abs.yaml
+++ b/abs.yaml
@@ -1,0 +1,4 @@
+build_parameters:
+  - "--suppress-variables"
+  - "--skip-existing"
+  - "--error-overlinking"

--- a/recipe/bld.bat
+++ b/recipe/bld.bat
@@ -17,7 +17,8 @@ cmake .. %CMAKE_ARGS% ^
       -DCMAKE_BUILD_TYPE=Release ^
       ^
       -DBUILD_DOCS=OFF ^
-      -DBUILD_MOCK=OFF
+      -DBUILD_MOCK=OFF ^
+      -DCMAKE_POLICY_VERSION_MINIMUM=3.5
 
 
 :: Build.

--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -16,7 +16,8 @@ cmake .. ${CMAKE_ARGS} \
       -DCMAKE_BUILD_TYPE=Release \
       \
       -DBUILD_DOCS=OFF \
-      -DBUILD_MOCK=OFF
+      -DBUILD_MOCK=OFF \
+      -DCMAKE_POLICY_VERSION_MINIMUM=3.5
 
 # Build.
 echo "Building..."

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -14,8 +14,6 @@ build:
 
 requirements:
   build:
-    - {{ compiler('c') }}
-    - {{ compiler('cxx') }}
     - cmake
     - ninja-base
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -14,6 +14,9 @@ build:
 
 requirements:
   build:
+    # Compilers needed: upstream project() declares C and CXX languages
+    - {{ compiler('c') }}
+    - {{ compiler('cxx') }}
     - cmake
     - ninja-base
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,17 +1,16 @@
-{% set version = "0.7" %}
-{% set build_number = "0" %}
-{% set sha_hash = "13f60672b324d081545f423d720737121c4952a9b90bdd49dc372a84c3fe96ee" %}
+{% set name = "dlpack" %}
+{% set version = "1.1" %}
 
 package:
-  name: dlpack
+  name: {{ name }}
   version: {{ version }}
 
 source:
   url: https://github.com/dmlc/dlpack/archive/v{{ version }}.tar.gz
-  sha256: {{ sha_hash }}
+  sha256: 2e3b94b55825c240cc58e6721e15b449978cbae21a2a4caa23058b0157ee2fb3
 
 build:
-  number: {{ build_number }}
+  number: 0
 
 requirements:
   build:
@@ -22,8 +21,11 @@ requirements:
 
 test:
   commands:
-    - test -f ${PREFIX}/include/dlpack/dlpack.h                     # [unix]
-    - if not exist %PREFIX%\Library\include\dlpack\dlpack.h exit 1  # [win]
+    - test -d ${PREFIX}/include/dlpack                   # [unix]
+    - test -f ${PREFIX}/include/dlpack/dlpack.h          # [unix]
+    - test -d ${PREFIX}/lib/cmake/dlpack                 # [unix]
+    - if not exist %LIBRARY_INC%\dlpack\dlpack.h exit 1  # [win]
+    - if not exist %LIBRARY_LIB%\cmake\dlpack exit 1     # [win]
 
 about:
   home: https://github.com/dmlc/dlpack
@@ -32,7 +34,8 @@ about:
   license_file: LICENSE
   summary: DLPack - Open In Memory Tensor Structure
   description: |
-    DLPack is an open in-memory tensor structure to for sharing tensor among frameworks
+    DLPack is an open in-memory tensor structure for sharing tensors among frameworks.
+  doc_url: https://dmlc.github.io/dlpack/latest
   dev_url: https://github.com/dmlc/dlpack
 
 extra:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -6,7 +6,7 @@ package:
   version: {{ version }}
 
 source:
-  url: https://github.com/dmlc/dlpack/archive/v{{ version }}.tar.gz
+  url: https://github.com/dmlc/{{ name }}/archive/v{{ version }}.tar.gz
   sha256: 2e3b94b55825c240cc58e6721e15b449978cbae21a2a4caa23058b0157ee2fb3
 
 build:
@@ -40,6 +40,7 @@ about:
 
 extra:
   recipe-maintainers:
+    - leofang
     - marcelotrevisani
     - kkraus14
     - jakirkham


### PR DESCRIPTION
dlpack 1.1

**Destination channel:** defaults

### Links

- [PKG-13060](https://anaconda.atlassian.net/browse/PKG-13060)
- [Upstream repository](https://github.com/dmlc/dlpack)
- [Upstream changelog/diff](https://github.com/dmlc/dlpack/compare/v0.7...v1.1)

### Explanation of changes:

- Update dlpack from 0.7 to 1.1 (header-only C++ library for tensor sharing)
- Added cmake config dir test, doc_url, improved Windows test paths

[PKG-13060]: https://anaconda.atlassian.net/browse/PKG-13060?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ